### PR TITLE
Change Node engine from v12 to v14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v2.3.4
     - uses: actions/setup-node@v2.2.0
       with:
-        node-version: '12.x'
+        node-version: '14.x'
         cache: npm
     - run: npm ci
     - run: npm run check
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/checkout@v2.3.4
     - uses: actions/setup-node@v2.2.0
       with:
-        node-version: '12.x'
+        node-version: '14.x'
         cache: npm
     - run: npm ci
     - name: Deploy to search.developer.stage.swedbankpay.com

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,2 @@
-v12
+v14
 engine-strict=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   search:
-    image: node:12-alpine
+    image: node:14-alpine
     container_name: search.developer.swedbankpay.com
     restart: unless-stopped
     environment:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": "^12",
+    "node": "^14",
     "npm": ">=6"
   },
   "scripts": {


### PR DESCRIPTION
Change Node engine from v12 to v14. Let's see if Azure supports sourcing the Node version from package.json