### PR TITLE
DX-1602: Bump jest and install ansi-regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -923,12 +923,12 @@
       }
     },
     "@babel/plugin-syntax-top-level-await": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
-      "integrity": "sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-syntax-typescript": {
@@ -2521,16 +2521,16 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.6.tgz",
-      "integrity": "sha512-fMlIBocSHPZ3JxgWiDNW/KPj6s+YRd0hicb33IrmelCcjXo/pXPwvuiKFmZz+XuqI/1u7nbUK10zSsWL/1aegg==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.2.3.tgz",
+      "integrity": "sha512-7akAz7p6T31EEYVVKxs6fKaR7CUgem22M/0TjCP7a64FIhNif2EiWcRzMkkDZbYhImG+Tz5qy9gMk2Wtl5GV1g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-message-util": "^27.2.3",
+        "jest-util": "^27.2.3",
         "slash": "^3.0.0"
       },
       "dependencies": {
@@ -2544,9 +2544,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2586,35 +2586,35 @@
       }
     },
     "@jest/core": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.6.tgz",
-      "integrity": "sha512-SsYBm3yhqOn5ZLJCtccaBcvD/ccTLCeuDv8U41WJH/V1MW5eKUkeMHT9U+Pw/v1m1AIWlnIW/eM2XzQr0rEmow==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.2.3.tgz",
+      "integrity": "sha512-I+VX+X8pkw2I057swT3ufNp6V5EBeFO1dl+gvIexdV0zg1kZ+cz9CrPbWL75dYrJIInf5uWPwDwOoJCALrTxWw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/reporters": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.2.3",
+        "@jest/reporters": "^27.2.3",
+        "@jest/test-result": "^27.2.3",
+        "@jest/transform": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.0.6",
-        "jest-config": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-message-util": "^27.0.6",
+        "jest-changed-files": "^27.2.3",
+        "jest-config": "^27.2.3",
+        "jest-haste-map": "^27.2.3",
+        "jest-message-util": "^27.2.3",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-resolve-dependencies": "^27.0.6",
-        "jest-runner": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
-        "jest-watcher": "^27.0.6",
+        "jest-resolve": "^27.2.3",
+        "jest-resolve-dependencies": "^27.2.3",
+        "jest-runner": "^27.2.3",
+        "jest-runtime": "^27.2.3",
+        "jest-snapshot": "^27.2.3",
+        "jest-util": "^27.2.3",
+        "jest-validate": "^27.2.3",
+        "jest-watcher": "^27.2.3",
         "micromatch": "^4.0.4",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -2632,9 +2632,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2674,53 +2674,53 @@
       }
     },
     "@jest/environment": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.6.tgz",
-      "integrity": "sha512-4XywtdhwZwCpPJ/qfAkqExRsERW+UaoSRStSHCCiQTUpoYdLukj+YJbQSFrZjhlUDRZeNiU9SFH0u7iNimdiIg==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.2.3.tgz",
+      "integrity": "sha512-xXZk/Uhq6TTRydg4RyNawNZ82lX88r3997t5ykzQBfB3Wd+mqzSyC4XWzw4lTZJISldwn9/FunexTSGBFcvVAg==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/fake-timers": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/node": "*",
-        "jest-mock": "^27.0.6"
+        "jest-mock": "^27.2.3"
       }
     },
     "@jest/fake-timers": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.6.tgz",
-      "integrity": "sha512-sqd+xTWtZ94l3yWDKnRTdvTeZ+A/V7SSKrxsrOKSqdyddb9CeNRF8fbhAU0D7ZJBpTTW2nbp6MftmKJDZfW2LQ==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.2.3.tgz",
+      "integrity": "sha512-A8+X35briNiabUPcLqYQY+dsvBUozX9DCa7HgJLdvRK/JPAKUpthYHjnI9y6QUYaDTqGZEo4rLf7LXE51MwP3Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
-        "@sinonjs/fake-timers": "^7.0.2",
+        "@jest/types": "^27.2.3",
+        "@sinonjs/fake-timers": "^8.0.1",
         "@types/node": "*",
-        "jest-message-util": "^27.0.6",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6"
+        "jest-message-util": "^27.2.3",
+        "jest-mock": "^27.2.3",
+        "jest-util": "^27.2.3"
       }
     },
     "@jest/globals": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.6.tgz",
-      "integrity": "sha512-DdTGCP606rh9bjkdQ7VvChV18iS7q0IMJVP1piwTWyWskol4iqcVwthZmoJEf7obE1nc34OpIyoVGPeqLC+ryw==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.3.tgz",
+      "integrity": "sha512-JVjQDs5z34XvFME0qHmKwWtgzRnBa/i22nfWjzlIUvkdFCzndN+JTLEWNXAgyBbGnNYuMZ8CpvgF9uhKt/cR3g==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/types": "^27.0.6",
-        "expect": "^27.0.6"
+        "@jest/environment": "^27.2.3",
+        "@jest/types": "^27.2.3",
+        "expect": "^27.2.3"
       }
     },
     "@jest/reporters": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.6.tgz",
-      "integrity": "sha512-TIkBt09Cb2gptji3yJXb3EE+eVltW6BjO7frO7NEfjI9vSIYoISi5R3aI3KpEDXlB1xwB+97NXIqz84qYeYsfA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.2.3.tgz",
+      "integrity": "sha512-zc9gQDjUAnkRQ5C0LW2u4JU9Ojqp9qc8OXQkMSmAbou6lN0mvDGEl4PG5HrZxpW4nE2FjIYyX6JAn05QT3gLbw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.2.3",
+        "@jest/test-result": "^27.2.3",
+        "@jest/transform": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -2731,15 +2731,15 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-haste-map": "^27.2.3",
+        "jest-resolve": "^27.2.3",
+        "jest-util": "^27.2.3",
+        "jest-worker": "^27.2.3",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^8.0.0"
+        "v8-to-istanbul": "^8.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2752,9 +2752,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2819,45 +2819,45 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.6.tgz",
-      "integrity": "sha512-ja/pBOMTufjX4JLEauLxE3LQBPaI2YjGFtXexRAjt1I/MbfNlMx0sytSX3tn5hSLzQsR3Qy2rd0hc1BWojtj9w==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.2.3.tgz",
+      "integrity": "sha512-+pRxO4xSJyUxoA0ENiTq8wT+5RCFOxK4nlNY2lUes/VF33uB54GBkZeXlljZcZjuzS1Yarz4hZI/a4mBtv9jQA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.6.tgz",
-      "integrity": "sha512-bISzNIApazYOlTHDum9PwW22NOyDa6VI31n6JucpjTVM0jD6JDgqEZ9+yn575nDdPF0+4csYDxNNW13NvFQGZA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.2.3.tgz",
+      "integrity": "sha512-QskUVqLU2zzRYchI2Q9I9A2xnbDqGo70WIWkKf4+tD+BAkohDxOF46Q7iYxznPiRTcoYtqttSZiNSS4rgQDxrQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.6",
+        "@jest/test-result": "^27.2.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
-        "jest-runtime": "^27.0.6"
+        "jest-haste-map": "^27.2.3",
+        "jest-runtime": "^27.2.3"
       }
     },
     "@jest/transform": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.6.tgz",
-      "integrity": "sha512-rj5Dw+mtIcntAUnMlW/Vju5mr73u8yg+irnHwzgtgoeI6cCPOvUwQ0D1uQtc/APmWgvRweEb1g05pkUpxH3iCA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.2.3.tgz",
+      "integrity": "sha512-ZpYsc9vK+OfV/9hMsVOrCH/9rvzBHAp91OOzkLqdWf3FWpDzjxAH+OlLGcS4U8WeWsdpe8/rOMKLwFs9DwL/2A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
+        "jest-haste-map": "^27.2.3",
         "jest-regex-util": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-util": "^27.2.3",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -2875,9 +2875,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2923,9 +2923,9 @@
       }
     },
     "@jest/types": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
-      "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.3.tgz",
+      "integrity": "sha512-UJMDg90+W2i/QsS1NIN6Go8O/rSHLFWUkofGqKsUQs54mhmCVyLTiDy1cwKhoNO5fpmr9fctm9L/bRp/YzA1uQ==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2945,9 +2945,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -3002,9 +3002,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.0.1.tgz",
+      "integrity": "sha512-AU7kwFxreVd6OAXcAFlKSmZquiRUU0FvYm44k1Y1QbK7Co4m0aqfGMhjykIeQp/H6rcl+nFmj0zfdUcGVs9Dew==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -3026,9 +3026,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.14",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
-      "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
+      "integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -3039,18 +3039,18 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
-      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.3.tgz",
+      "integrity": "sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__template": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
-      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
+      "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -3058,9 +3058,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.0.tgz",
-      "integrity": "sha512-IilJZ1hJBUZwMOVDNTdflOOLzJB/ZtljYVa7k3gEZN/jqIJIPkWHC6dvbX+DD2CwZDHB9wAKzZPzzqMIkW37/w==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
+      "integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -3100,36 +3100,36 @@
       }
     },
     "@types/node": {
-      "version": "15.12.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
-      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+      "integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w==",
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==",
       "dev": true
     },
     "@types/stack-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
     "@types/yargs": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
-      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
     "abab": {
@@ -3153,9 +3153,9 @@
       }
     },
     "acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
       "dev": true
     },
     "acorn-globals": {
@@ -3250,9 +3250,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "dev": true
     },
     "ansi-styles": {
@@ -3294,16 +3294,16 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.6.tgz",
-      "integrity": "sha512-iTJyYLNc4wRofASmofpOc5NK9QunwMk+TLFgGXsTFS8uEqmd8wdI7sga0FPe2oVH3b5Agt/EAK1QjPEuKL8VfA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.3.tgz",
+      "integrity": "sha512-lXslrpae1L9cXnB5F8vvD/Yj70g47sG7CGSxT+qqveK/To72X3nuCtDux0s3HN7X351IbwYoYyfDxQ7CqVbkNw==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/transform": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^27.0.6",
+        "babel-preset-jest": "^27.2.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
@@ -3319,9 +3319,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -3382,9 +3382,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz",
-      "integrity": "sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.2.0.tgz",
+      "integrity": "sha512-TOux9khNKdi64mW+0OIhcmbAn75tTlzKhxmiNXevQaPbrBYK7YKjP1jl6NHTJ6XR5UgUrJbCnWlKVnJn29dfjw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -3441,12 +3441,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
-      "integrity": "sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.2.0.tgz",
+      "integrity": "sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^27.0.6",
+        "babel-plugin-jest-hoist": "^27.2.0",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -3748,9 +3748,9 @@
       "dev": true
     },
     "cjs-module-lexer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz",
-      "integrity": "sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
+      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
     "cli-boxes": {
@@ -4076,9 +4076,9 @@
       "dev": true
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "deepmerge": {
@@ -4304,16 +4304,16 @@
       "dev": true
     },
     "expect": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.6.tgz",
-      "integrity": "sha512-psNLt8j2kwg42jGBDSfAlU49CEZxejN1f1PlANWDZqIhBOVU/c2Pm888FcjWJzFewhIsNWfZJeLjUjtKGiPuSw==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.3.tgz",
+      "integrity": "sha512-qT+ItBIdpS2QkRzZNGFmqpV2xTjK20gftUnJ4CLmpjdGzpoEtjxb43Y80GraXLtwB+wt5kRmXURINeM3s2fQtQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
+        "jest-matcher-utils": "^27.2.3",
+        "jest-message-util": "^27.2.3",
         "jest-regex-util": "^27.0.6"
       },
       "dependencies": {
@@ -4913,9 +4913,9 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
     "is-typedarray": {
@@ -4942,9 +4942,9 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.1.tgz",
+      "integrity": "sha512-GvCYYTxaCPqwMjobtVcVKvSHtAGe48MNhGjpK8LtVF8K0ISX7hCKl85LgtuaSneWVyQmaGcW3iXVV3GaZSLpmQ==",
       "dev": true
     },
     "istanbul-lib-instrument": {
@@ -5026,52 +5026,14 @@
       }
     },
     "jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.6.tgz",
-      "integrity": "sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.2.3.tgz",
+      "integrity": "sha512-r4ggA29J5xUg93DpvbsX+AXlFMWE3hZ5Y6BfgTl8PJvWelVezNPkmrsixuGoDBTHTCwScRSH0O4wsoeUgLie2w==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.0.6",
+        "@jest/core": "^27.2.3",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.0.6"
-      }
-    },
-    "jest-changed-files": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.6.tgz",
-      "integrity": "sha512-BuL/ZDauaq5dumYh5y20sn4IISnf1P9A0TDswTxUi84ORGtVa86ApuBHqICL0vepqAnZiY6a7xeSPWv2/yy4eA==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^27.0.6",
-        "execa": "^5.0.0",
-        "throat": "^6.0.1"
-      }
-    },
-    "jest-circus": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.6.tgz",
-      "integrity": "sha512-OJlsz6BBeX9qR+7O9lXefWoc2m9ZqcZ5Ohlzz0pTEAG4xMiZUJoacY8f4YDHxgk0oKYxj277AfOk9w6hZYvi1Q==",
-      "dev": true,
-      "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "dedent": "^0.7.0",
-        "expect": "^27.0.6",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3",
-        "throat": "^6.0.1"
+        "jest-cli": "^27.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5084,9 +5046,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5114,6 +5076,26 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "jest-cli": {
+          "version": "27.2.3",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.2.3.tgz",
+          "integrity": "sha512-QHXxxqE1zxMlti6wIHSbkl4Brg5Dnc0xzAVqRlVa6y2Ygv2X4ejhfMjl4VB5gWeHNsVA9C+KOm8TawpjZX8d3g==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^27.2.3",
+            "@jest/test-result": "^27.2.3",
+            "@jest/types": "^27.2.3",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "import-local": "^3.0.2",
+            "jest-config": "^27.2.3",
+            "jest-util": "^27.2.3",
+            "jest-validate": "^27.2.3",
+            "prompts": "^2.0.1",
+            "yargs": "^16.0.3"
+          }
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5125,24 +5107,42 @@
         }
       }
     },
-    "jest-cli": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.6.tgz",
-      "integrity": "sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==",
+    "jest-changed-files": {
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.2.3.tgz",
+      "integrity": "sha512-UiT98eMtPySry7E0RmkDTL/GyoZBvJVWZBlHpHYc3ilRLxHBUxPkbMK/bcImDJKqyKbj83EaeIpeaMXPlPQ72A==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
+        "execa": "^5.0.0",
+        "throat": "^6.0.1"
+      }
+    },
+    "jest-circus": {
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.2.3.tgz",
+      "integrity": "sha512-msCZkvudSDhUtCCEU/Dsnp5DRzX5MQGwfuRjDwhxJxjSJ0g4c3Qwhk5Q2AjFjZS9EVm4qs9fGCf+W3BU69h3pw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^27.2.3",
+        "@jest/test-result": "^27.2.3",
+        "@jest/types": "^27.2.3",
+        "@types/node": "*",
         "chalk": "^4.0.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.4",
-        "import-local": "^3.0.2",
-        "jest-config": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
-        "prompts": "^2.0.1",
-        "yargs": "^16.0.3"
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "expect": "^27.2.3",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^27.2.3",
+        "jest-matcher-utils": "^27.2.3",
+        "jest-message-util": "^27.2.3",
+        "jest-runtime": "^27.2.3",
+        "jest-snapshot": "^27.2.3",
+        "jest-util": "^27.2.3",
+        "pretty-format": "^27.2.3",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3",
+        "throat": "^6.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5155,9 +5155,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5197,32 +5197,32 @@
       }
     },
     "jest-config": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.6.tgz",
-      "integrity": "sha512-JZRR3I1Plr2YxPBhgqRspDE2S5zprbga3swYNrvY3HfQGu7p/GjyLOqwrYad97tX3U3mzT53TPHVmozacfP/3w==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.2.3.tgz",
+      "integrity": "sha512-15fKPBZ+eiDUj02bENeBNL6IrH9ZQg7mcOlJ+SG8HwEkjpy0K+NHAREFIJbPFBaq75syWk9SYkB77fH0XtoZOQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.0.6",
-        "@jest/types": "^27.0.6",
-        "babel-jest": "^27.0.6",
+        "@jest/test-sequencer": "^27.2.3",
+        "@jest/types": "^27.2.3",
+        "babel-jest": "^27.2.3",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.0.6",
-        "jest-environment-jsdom": "^27.0.6",
-        "jest-environment-node": "^27.0.6",
+        "jest-circus": "^27.2.3",
+        "jest-environment-jsdom": "^27.2.3",
+        "jest-environment-node": "^27.2.3",
         "jest-get-type": "^27.0.6",
-        "jest-jasmine2": "^27.0.6",
+        "jest-jasmine2": "^27.2.3",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-runner": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-resolve": "^27.2.3",
+        "jest-runner": "^27.2.3",
+        "jest-util": "^27.2.3",
+        "jest-validate": "^27.2.3",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5235,9 +5235,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5277,15 +5277,15 @@
       }
     },
     "jest-diff": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
-      "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.3.tgz",
+      "integrity": "sha512-ihRKT1mbm/Lw+vaB1un4BEof3WdfYIXT0VLvEyLUTU3XbIUgyiljis3YzFf2RFn+ECFAeyilqJa35DeeRV2NeQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.0.6",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5298,9 +5298,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5349,16 +5349,16 @@
       }
     },
     "jest-each": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.6.tgz",
-      "integrity": "sha512-m6yKcV3bkSWrUIjxkE9OC0mhBZZdhovIW5ergBYirqnkLXkyEn3oUUF/QZgyecA1cF1QFyTE8bRRl8Tfg1pfLA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.2.3.tgz",
+      "integrity": "sha512-Aza5Lr+tml8x+rBGsi3A8VLqhYN1UBa2M7FLtgkUvVFQBORlV9irLl/ZE0tvk4hRqp4jW7nbGDrRo2Ey8Wl9rg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "jest-util": "^27.2.3",
+        "pretty-format": "^27.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5371,9 +5371,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5413,32 +5413,32 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz",
-      "integrity": "sha512-FvetXg7lnXL9+78H+xUAsra3IeZRTiegA3An01cWeXBspKXUhAwMM9ycIJ4yBaR0L7HkoMPaZsozCLHh4T8fuw==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.2.3.tgz",
+      "integrity": "sha512-QEcgd5bloEfugjvYFACFtFkn5sW9fGYS/vJaTQZ2kj8/q1semDYWssbUWeT8Lmm/4utv9G50+bTq/vGP/LZwvQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.2.3",
+        "@jest/fake-timers": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/node": "*",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-mock": "^27.2.3",
+        "jest-util": "^27.2.3",
         "jsdom": "^16.6.0"
       }
     },
     "jest-environment-node": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.6.tgz",
-      "integrity": "sha512-+Vi6yLrPg/qC81jfXx3IBlVnDTI6kmRr08iVa2hFCWmJt4zha0XW7ucQltCAPhSR0FEKEoJ3i+W4E6T0s9is0w==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.2.3.tgz",
+      "integrity": "sha512-OmxFyQ81n1pQ+WJW7tOkGPQL/nt0+UeubHlZJEdAzuOvYAA8zleamw0BpK7QsITdJ5euSI6t/HW3a5ihqMB4yQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.2.3",
+        "@jest/fake-timers": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/node": "*",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6"
+        "jest-mock": "^27.2.3",
+        "jest-util": "^27.2.3"
       }
     },
     "jest-get-type": {
@@ -5448,12 +5448,12 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.6.tgz",
-      "integrity": "sha512-4ldjPXX9h8doB2JlRzg9oAZ2p6/GpQUNAeiYXqcpmrKbP0Qev0wdZlxSMOmz8mPOEnt4h6qIzXFLDi8RScX/1w==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.2.3.tgz",
+      "integrity": "sha512-5KE0vRSGv1Ymhd6s1t6xhTm/77otdkzqJl+9pSIYfKKCKJ7cniyE2zVC/Xj2HKuMX++aJYzQvQCIS0kqIFukAw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -5462,35 +5462,35 @@
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-util": "^27.2.3",
+        "jest-worker": "^27.2.3",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       }
     },
     "jest-jasmine2": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz",
-      "integrity": "sha512-cjpH2sBy+t6dvCeKBsHpW41mjHzXgsavaFMp+VWRf0eR4EW8xASk1acqmljFtK2DgyIECMv2yCdY41r2l1+4iA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.2.3.tgz",
+      "integrity": "sha512-pjgANGYj1l6qxBkSPEYuxGvqVVf20uJ26XpNnYV/URC7ayt+UdRavUhEwzDboiewq/lCgNFCDBEqd6eeQVEs8w==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.0.6",
+        "@jest/environment": "^27.2.3",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/test-result": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.0.6",
+        "expect": "^27.2.3",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6",
+        "jest-each": "^27.2.3",
+        "jest-matcher-utils": "^27.2.3",
+        "jest-message-util": "^27.2.3",
+        "jest-runtime": "^27.2.3",
+        "jest-snapshot": "^27.2.3",
+        "jest-util": "^27.2.3",
+        "pretty-format": "^27.2.3",
         "throat": "^6.0.1"
       },
       "dependencies": {
@@ -5504,9 +5504,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5546,25 +5546,25 @@
       }
     },
     "jest-leak-detector": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.6.tgz",
-      "integrity": "sha512-2/d6n2wlH5zEcdctX4zdbgX8oM61tb67PQt4Xh8JFAIy6LRKUnX528HulkaG6nD5qDl5vRV1NXejCe1XRCH5gQ==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.2.3.tgz",
+      "integrity": "sha512-hoV8d7eJvayIaPrISBoLaMN0DE+GRSR2/vbAcOONffO+RYzbuW3klsOievx+pCShYKxSKlhxxO90zWice+LLew==",
       "dev": true,
       "requires": {
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.2.3"
       }
     },
     "jest-matcher-utils": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.6.tgz",
-      "integrity": "sha512-OFgF2VCQx9vdPSYTHWJ9MzFCehs20TsyFi6bIHbk5V1u52zJOnvF0Y/65z3GLZHKRuTgVPY4Z6LVePNahaQ+tA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.3.tgz",
+      "integrity": "sha512-8n2/iAEOtNoDxVtUuaGtQdbSVYtZn6saT+PyV8UIf9fJErzDdozjB4fUxJm7TX1DzhhoAKFpIFH8UNvG4942PA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.0.6",
+        "jest-diff": "^27.2.3",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5577,9 +5577,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5619,18 +5619,18 @@
       }
     },
     "jest-message-util": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.6.tgz",
-      "integrity": "sha512-rBxIs2XK7rGy+zGxgi+UJKP6WqQ+KrBbD1YMj517HYN3v2BG66t3Xan3FWqYHKZwjdB700KiAJ+iES9a0M+ixw==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.2.3.tgz",
+      "integrity": "sha512-yjVqTQ2Ds1WCGXsTuW0m1uK8RXOE44SJDw7tWUrhn6ZttWDbPmLhH8npDsGGfAmSayKFSo2C0NX0tP2qblc3Gw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.6",
+        "pretty-format": "^27.2.3",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -5645,9 +5645,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5687,12 +5687,12 @@
       }
     },
     "jest-mock": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.6.tgz",
-      "integrity": "sha512-lzBETUoK8cSxts2NYXSBWT+EJNzmUVtVVwS1sU9GwE1DLCfGsngg+ZVSIe0yd0ZSm+y791esiuo+WSwpXJQ5Bw==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.2.3.tgz",
+      "integrity": "sha512-IvgCdUQBU/XDJl9/NLYtKG9o2XlJOQ8hFYDiX7QmNv2195Y1nNGM7hw1H58wT01zz7bohfhJplqwFfULZlrXjg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "@types/node": "*"
       }
     },
@@ -5709,18 +5709,19 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.6.tgz",
-      "integrity": "sha512-yKmIgw2LgTh7uAJtzv8UFHGF7Dm7XfvOe/LQ3Txv101fLM8cx2h1QVwtSJ51Q/SCxpIiKfVn6G2jYYMDNHZteA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.2.3.tgz",
+      "integrity": "sha512-+tbm53gKpwuRsqCV+zhhjq/6NxMs/I9zECEMzu0LtmbYD5Gusj+rU497f6lkl5LG/GndvfTjJlysYrnSCcZUJA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "chalk": "^4.0.0",
         "escalade": "^3.1.1",
         "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.2.3",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-util": "^27.2.3",
+        "jest-validate": "^27.2.3",
         "resolve": "^1.20.0",
         "slash": "^3.0.0"
       },
@@ -5735,9 +5736,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5777,42 +5778,42 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.6.tgz",
-      "integrity": "sha512-mg9x9DS3BPAREWKCAoyg3QucCr0n6S8HEEsqRCKSPjPcu9HzRILzhdzY3imsLoZWeosEbJZz6TKasveczzpJZA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.3.tgz",
+      "integrity": "sha512-H03NyzmKfYHCciaYBJqbJOrWCVCdwdt32xZDPFP5dBbe39wsfz41aOkhw8FUZ6qVYVO6rz0nLZ3G7wgbsQQsYQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.0.6"
+        "jest-snapshot": "^27.2.3"
       }
     },
     "jest-runner": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.6.tgz",
-      "integrity": "sha512-W3Bz5qAgaSChuivLn+nKOgjqNxM7O/9JOJoKDCqThPIg2sH/d4A/lzyiaFgnb9V1/w29Le11NpzTJSzga1vyYQ==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.2.3.tgz",
+      "integrity": "sha512-bvGlIh3wR/LGjSHPW/IpQU6K2atO45U5p7UDqWThPKT622Wm/ZJ2DNbgNzb4P9ZO/UxB22jXoKJPsMAdWGEdmA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/environment": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.2.3",
+        "@jest/environment": "^27.2.3",
+        "@jest/test-result": "^27.2.3",
+        "@jest/transform": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-docblock": "^27.0.6",
-        "jest-environment-jsdom": "^27.0.6",
-        "jest-environment-node": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-leak-detector": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-environment-jsdom": "^27.2.3",
+        "jest-environment-node": "^27.2.3",
+        "jest-haste-map": "^27.2.3",
+        "jest-leak-detector": "^27.2.3",
+        "jest-message-util": "^27.2.3",
+        "jest-resolve": "^27.2.3",
+        "jest-runtime": "^27.2.3",
+        "jest-util": "^27.2.3",
+        "jest-worker": "^27.2.3",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       },
@@ -5827,9 +5828,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5869,34 +5870,35 @@
       }
     },
     "jest-runtime": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.6.tgz",
-      "integrity": "sha512-BhvHLRVfKibYyqqEFkybsznKwhrsu7AWx2F3y9G9L95VSIN3/ZZ9vBpm/XCS2bS+BWz3sSeNGLzI3TVQ0uL85Q==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.2.3.tgz",
+      "integrity": "sha512-8WPgxENQchmUM0jpDjK1IxacseK9vDDz6T471xs5pNIQrj8typeT0coRigRCb1sPYeXQ66SqVERMgPj6SEeblQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/globals": "^27.0.6",
+        "@jest/console": "^27.2.3",
+        "@jest/environment": "^27.2.3",
+        "@jest/fake-timers": "^27.2.3",
+        "@jest/globals": "^27.2.3",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/test-result": "^27.2.3",
+        "@jest/transform": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
+        "execa": "^5.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-mock": "^27.0.6",
+        "jest-haste-map": "^27.2.3",
+        "jest-message-util": "^27.2.3",
+        "jest-mock": "^27.2.3",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-resolve": "^27.2.3",
+        "jest-snapshot": "^27.2.3",
+        "jest-util": "^27.2.3",
+        "jest-validate": "^27.2.3",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^16.0.3"
@@ -5912,9 +5914,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5964,9 +5966,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.6.tgz",
-      "integrity": "sha512-NTHaz8He+ATUagUgE7C/UtFcRoHqR2Gc+KDfhQIyx+VFgwbeEMjeP+ILpUTLosZn/ZtbNdCF5LkVnN/l+V751A==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.2.3.tgz",
+      "integrity": "sha512-NJz+PNvTNTxVfNdLXccKUMeVH5O7jZ+9dNXH5TP2WtkLR+CiPRiPveWDgM8o3aaxB6R0Mm8vsD7ieEkEh6ZBBQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -5975,23 +5977,23 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/transform": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.0.6",
+        "expect": "^27.2.3",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.0.6",
+        "jest-diff": "^27.2.3",
         "jest-get-type": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-haste-map": "^27.2.3",
+        "jest-matcher-utils": "^27.2.3",
+        "jest-message-util": "^27.2.3",
+        "jest-resolve": "^27.2.3",
+        "jest-util": "^27.2.3",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.0.6",
+        "pretty-format": "^27.2.3",
         "semver": "^7.3.2"
       },
       "dependencies": {
@@ -6005,9 +6007,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6071,12 +6073,12 @@
       }
     },
     "jest-util": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.6.tgz",
-      "integrity": "sha512-1JjlaIh+C65H/F7D11GNkGDDZtDfMEM8EBXsvd+l/cxtgQ6QhxuloOaiayt89DxUvDarbVhqI98HhgrM1yliFQ==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.3.tgz",
+      "integrity": "sha512-78BEka2+77lqD7LN4mSzUdZMngHZtVAsmZ5B8+qOWfN4bCYNUmi/eGNLm91jA77gG1QZJSXsDOCWB0qbXDT1Fw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -6094,9 +6096,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6136,17 +6138,17 @@
       }
     },
     "jest-validate": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.6.tgz",
-      "integrity": "sha512-yhZZOaMH3Zg6DC83n60pLmdU1DQE46DW+KLozPiPbSbPhlXXaiUTDlhHQhHFpaqIFRrInko1FHXjTRpjWRuWfA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.2.3.tgz",
+      "integrity": "sha512-HUfTZ/W87zoxOuEGC01ujXzoLzRpJqvhMdIrRilpXGmso2vJWw3bHpbWKhivYMr0X/BjitLrHywj/+niNfIcEA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.2.3",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6165,9 +6167,9 @@
           "dev": true
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6207,17 +6209,17 @@
       }
     },
     "jest-watcher": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.6.tgz",
-      "integrity": "sha512-/jIoKBhAP00/iMGnTwUBLgvxkn7vsOweDrOTSPzc7X9uOyUtJIDthQBTI1EXz90bdkrxorUZVhJwiB69gcHtYQ==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.2.3.tgz",
+      "integrity": "sha512-SvUmnL/QMb55B6iWJ3Jpq6bG2fSRcrMaGakY60i6j8p9+Ct42mpkq90qaYB+rnSLaiW/QQN+lTJZmK+lA6vksA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/test-result": "^27.2.3",
+        "@jest/types": "^27.2.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.0.6",
+        "jest-util": "^27.2.3",
         "string-length": "^4.0.1"
       },
       "dependencies": {
@@ -6231,9 +6233,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6273,9 +6275,9 @@
       }
     },
     "jest-worker": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
-      "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.3.tgz",
+      "integrity": "sha512-ZwOvv4GCIPviL+Ie4pVguz4N5w/6IGbTaHBYOl3ZcsZZktaL7d8JOU0rmovoED7AJZKA8fvmLbBg8yg80u/tGA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -6333,9 +6335,9 @@
       }
     },
     "jsdom": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
-      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
       "dev": true,
       "requires": {
         "abab": "^2.0.5",
@@ -6363,7 +6365,7 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.5.0",
-        "ws": "^7.4.5",
+        "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
       }
     },
@@ -6984,17 +6986,23 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-      "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+      "version": "27.2.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.3.tgz",
+      "integrity": "sha512-wvg2HzuGKKEE/nKY4VdQ/LM8w8pRZvp0XpqhwgaZBbjTwd5UdF2I4wvwZjyUwu8G+HI6g4t6u9b2FZlKhlzxcQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
-        "ansi-regex": "^5.0.0",
+        "@jest/types": "^27.2.3",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -7510,9 +7518,9 @@
       "dev": true
     },
     "stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -7576,6 +7584,14 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        }
       }
     },
     "strip-bom": {
@@ -8037,9 +8053,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "v8-to-istanbul": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
-      "integrity": "sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
+      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -8198,9 +8214,9 @@
       }
     },
     "ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-dom": "^17.0.1"
   },
   "devDependencies": {
-    "jest": "^27.0.6",
+    "ansi-regex": "^6.0.1",
+    "jest": "^27.2.3",
     "jquery": "^3.6.0",
     "nock": "^13.1.1",
     "nodemon": "^2.0.12",


### PR DESCRIPTION
Bump `jest` from version `27.0.6` to version `27.2.3` and install `ansi-regex` version `6.0.1` to fix CVE-2021-3807.